### PR TITLE
refactor: clean up builder creations and paths detection

### DIFF
--- a/src/deploy/builder.ts
+++ b/src/deploy/builder.ts
@@ -3,66 +3,49 @@ import {
   BuilderOutput,
   createBuilder
 } from '@angular-devkit/architect';
-import { asWindowsPath, experimental, normalize } from '@angular-devkit/core';
-import { NodeJsSyncHost } from '@angular-devkit/core/node';
-import os from 'os';
+import { json } from '@angular-devkit/core';
 import * as path from 'path';
 
 import * as engine from '../engine/engine';
 import deploy from './actions';
 import { Schema } from './schema';
 
-// Call the createBuilder() function to create a builder. This mirrors
-// createJobHandler() but add typings specific to Architect Builders.
-export default createBuilder<any>(
-  async (options: Schema, context: BuilderContext): Promise<BuilderOutput> => {
-    try {
-      // The project root is added to a BuilderContext.
-      const root = normalize(context.workspaceRoot);
-      const workspace = new experimental.workspace.Workspace(
-        root,
-        new NodeJsSyncHost()
-      );
-      await workspace
-        .loadWorkspaceFromHost(normalize('angular.json'))
-        .toPromise();
+export type DeployBuilderOptions = Schema & json.JsonObject;
 
-      if (!context.target) {
-        throw new Error('Cannot deploy the application without a target');
-      }
-
-      const targets = workspace.getProjectTargets(context.target.project);
-
-      if (
-        !targets ||
-        !targets.build ||
-        !targets.build.options ||
-        !targets.build.options.outputPath
-      ) {
-        throw new Error('Cannot find the project output directory');
-      }
-
-      // normalizes pathes don't work with all native functions
-      // as a workaround, you can use the following 2 lines
-      const isWin = os.platform() === 'win32';
-      const workspaceRoot = !isWin
-        ? workspace.root
-        : asWindowsPath(workspace.root);
-      // if this is not necessary, use this:
-      // const workspaceRoot =  workspace.root;
-
-      await deploy(
-        engine,
-        context,
-        path.join(workspaceRoot, targets.build.options.outputPath),
-        options
-      );
-    } catch (e) {
-      context.logger.error('❌ An error occurred when trying to deploy:');
-      context.logger.error(e.message);
-      return { success: false };
+export async function execute(
+  options: DeployBuilderOptions,
+  context: BuilderContext,
+): Promise<BuilderOutput> {
+  try {
+    if (!context.target) {
+      throw new Error('Cannot deploy the application without a target');
     }
 
-    return { success: true };
+    const targets = context.getProjectTargets(context.target.project);
+
+    if (
+      !targets ||
+      !targets.build ||
+      !targets.build.options ||
+      !targets.build.options.outputPath
+    ) {
+      throw new Error('Cannot find the project output directory');
+    }
+
+    await deploy(
+      engine,
+      context,
+      path.join(context.workspaceRoot, targets.build.options.outputPath),
+      options
+    );
+  } catch (e) {
+    context.logger.error('❌ An error occurred when trying to deploy:');
+    context.logger.error(e.message);
+    return { success: false, error: e.message };
   }
-);
+
+  return { success: true };
+}
+
+
+export default createBuilder<DeployBuilderOptions, BuilderOutput>(execute);


### PR DESCRIPTION
Use workspaceRoot instead of workspace.root. The former uses FS paths while the latter uses Devkit paths. These are not interchangeable.