### PR TITLE
build: create a separate tsconfig file for build

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -4,7 +4,9 @@
   "description": "Deployment from the Angular CLI to the file system. This is a sample project that helps you to implement your own deployment builder (`ng deploy`) for the Angular CLI.",
   "main": "index.js",
   "scripts": {
-    "build": "rimraf dist && json2ts deploy/schema.json > deploy/schema.d.ts && tsc && copyfiles README.md builders.json collection.json ng-add-schema.json package.json ngx-deploy-starter deploy/schema.json dist",
+    "prebuild": "rimraf dist && json2ts deploy/schema.json > deploy/schema.d.ts",
+    "build": "tsc -p tsconfig.build.json",
+    "postbuild": "copyfiles README.md builders.json collection.json ng-add-schema.json package.json ngx-deploy-starter deploy/schema.json dist",
     "test": "jest",
     "prettier": "prettier --write ."
   },

--- a/src/tsconfig.build.json
+++ b/src/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "test", "**/*spec.ts"]
+}


### PR DESCRIPTION
I've seen that is a common practice between typescript projects to have separate tsconfig files, Angular and Nest do that.

Also, I've been discovering some improvements using this configuration on [my fork](https://github.com/bikecoders/ngx-deploy-npm):

### The build is independent for the test

Currently, if there is a typo on the test, the build fails due to a compilation error. 
Very inconvenient when you are making some experiments and want to try them.

### The tests are not being compiled and added to the dist

On the final build, there is no need to put the test, they are useless there. This makes the compilation time faster _(0.02 sec faster on my machine 🤓)_ and the final library lighter. 